### PR TITLE
Fix mod.conf & make SkinsDB a hard dependency

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,5 @@
 name = clothing
-tittle = Clothing mod
-description = Add clothing to Minetest game. This mod is based on clothing mod from stujones11, bell07, SmallJoker and aerozoic. For available machines and clothes, use this with appliances mod. It is recomended to use this mod with skinsdb modi which makes clothing visible. 
+title = Clothing
+description = Add clothing to Minetest Game. This mod is based on the clothing mod from stujones11, bell07, SmallJoker and aerozoic. For available machines and clothes, use this with appliances mod. It is recommended to use this mod with skinsdb mod which makes clothing visible. 
+depends = skinsdb
 optional_depends = appliances, multiskin, sfinv, creative, inventory_plus, unified_inventory, wool, bucket, default, farming, bonemeal, skeletons, basic_materials


### PR DESCRIPTION
I was surprised that clothing didn't show until I read that SkinsDB is required. This makes SkinsDB a hard dependency because there's no point in invisible clothing and it is presented as a hard dependency in the Readme. I also noticed some minor mistakes and fixed them along the way.